### PR TITLE
Add logging for displaying status of script and clients as it processes

### DIFF
--- a/test_mediadownloadclient.py
+++ b/test_mediadownloadclient.py
@@ -4,20 +4,17 @@ import os
 import pickle
 import unittest
 
-import aiohttp
+from typing import Dict, List
+
 import dotenv
-import twitter_media_dl.mediadownloadclient as mdc
 import peony
 import peony.oauth
 
-from typing import Dict, List
+import twitter_media_dl.mediadownloadclient as mdc
 
 
 class Test_MediaDownloadClient(unittest.TestCase):
     # Stop mypy from complaining >:/
-    consumer_key: str
-    consumer_secret: str
-    bearer_token: str
     base_folder: str
     user_id: int
     example_tweet_ids: Dict[str, int]
@@ -26,39 +23,37 @@ class Test_MediaDownloadClient(unittest.TestCase):
     client: peony.BasePeonyClient
     cached_tweets: Dict[str, peony.data_processing.PeonyResponse]
     delete_later: List[str]
-   
+
     @classmethod
     def setUpClass(cls) -> None:
         try:
-            dotenv.load_dotenv("twitter_media_dl\.env")
-        finally:
-            cls.consumer_key = os.environ["CONSUMER_KEY"]
-            cls.consumer_secret = os.environ["CONSUMER_SECRET"]
-            cls.bearer_token = os.environ["BEARER_TOKEN"]
-            
+            dotenv.load_dotenv(os.path.join("twitter_media_dl", ".env"))
+        except FileNotFoundError:
+            pass
+
         cls.base_folder = os.path.join(os.path.dirname(__file__), "tests", "media")
         cls.user_id = 19701628  # @BBC official account
-        
+
         # Should add a "no_media" example to see what happens with no media
-        cls.example_tweet_ids = {"single_image":1373486756306165763, 
-                                 "multi_image":1412838462206615559, 
-                                 "animated_gif":1371930768306540546, 
-                                 "video":1372010047056711680, 
+        cls.example_tweet_ids = {"single_image":1373486756306165763,
+                                 "multi_image":1412838462206615559,
+                                 "animated_gif":1371930768306540546,
+                                 "video":1372010047056711680,
                                  "no_media":1373014297895448578}
         cls.example_types = {tweet_id: media_type for media_type, tweet_id in cls.example_tweet_ids.items()}
 
         cls.loop = asyncio.get_event_loop()
-        
+
         # LikesDownloadClient will be used as the testing client in this case
         # There is no real reason other than it is the "original" client for this project
         # Both LikesD.C. and TimelineD.C. share most functionality due to inheritance
         # so testing one should test the other well
         # Any class specific functionality will be tested separately
-        cls.client = mdc.LikesDownloadClient(cls.user_id, 
-                                             consumer_key=cls.consumer_key, 
-                                             consumer_secret=cls.consumer_secret,
-                                             bearer_token=cls.bearer_token,
-                                             auth=peony.oauth.OAuth2Headers, 
+        cls.client = mdc.LikesDownloadClient(cls.user_id,
+                                             consumer_key=os.environ["CONSUMER_KEY"],
+                                             consumer_secret=os.environ["CONSUMER_SECRET"],
+                                             bearer_token=os.environ["BEARER_TOKEN"],
+                                             auth=peony.oauth.OAuth2Headers,
                                              base_folder=cls.base_folder)
 
         # Get the tweets once when setting up, then just use these for each test
@@ -75,7 +70,7 @@ class Test_MediaDownloadClient(unittest.TestCase):
 
         cls.delete_later = []  # keep track of any files to delete after testing is complete
 
-    
+
     @classmethod
     def tearDownClass(cls) -> None:
         # Delete any downloaded files
@@ -100,16 +95,17 @@ class Test_MediaDownloadClient(unittest.TestCase):
             with self.subTest(media_type=media_type):
                 result = mdc.get_media_details([tweet])
                 self.assertEqual(result, expected[media_type])
+                result = []
 
 
     def test_get_filename(self):
-        expected = {"single_image":["img2021-03-21-040855_sad-istfied_0_1373486756306165763_Ew-a7MFU8AANIL9.jpg"], 
-                    "multi_image":["img2021-07-07-181833_dooblebugs_0_1412838462206615559_E5totsvVUAYexVX.png", 
-                                   "img2021-07-07-181833_dooblebugs_1_1412838462206615559_E5towDIVUAM0xv9.png", 
-                                   "img2021-07-07-181833_dooblebugs_2_1412838462206615559_E5toyv_VgAMmKwD.png", 
-                                   "img2021-07-07-181833_dooblebugs_3_1412838462206615559_E5to1YdUYAI9eek.png"], 
-                    "animated_gif":["gif2021-03-16-210559_dnoodels_1371930768306540546.mp4"], 
-                    "video":["video2021-03-17-022100_megateyourbagel_1372010047056711680.mp4"], 
+        expected = {"single_image":["img2021-03-21-040855_sad-istfied_0_1373486756306165763_Ew-a7MFU8AANIL9.jpg"],
+                    "multi_image":["img2021-07-07-181833_dooblebugs_0_1412838462206615559_E5totsvVUAYexVX.png",
+                                   "img2021-07-07-181833_dooblebugs_1_1412838462206615559_E5towDIVUAM0xv9.png",
+                                   "img2021-07-07-181833_dooblebugs_2_1412838462206615559_E5toyv_VgAMmKwD.png",
+                                   "img2021-07-07-181833_dooblebugs_3_1412838462206615559_E5to1YdUYAI9eek.png"],
+                    "animated_gif":["gif2021-03-16-210559_dnoodels_1371930768306540546.mp4"],
+                    "video":["video2021-03-17-022100_megateyourbagel_1372010047056711680.mp4"],
                     "no_media":[]}
 
         for media_type, tweet in self.cached_tweets.items():
@@ -121,14 +117,14 @@ class Test_MediaDownloadClient(unittest.TestCase):
                     result.append(mdc.get_filename(info))
                 self.assertEqual(result, expected[media_type])
 
-    
+
     def test_download_media(self):
-        expected = {"img2021-03-21-040855_sad-istfied_0_1373486756306165763_Ew-a7MFU8AANIL9.jpg": "single_image_media.jpg", 
-                    "img2021-07-07-181833_dooblebugs_0_1412838462206615559_E5totsvVUAYexVX.png": "multi_image_media1.png", 
-                    "img2021-07-07-181833_dooblebugs_1_1412838462206615559_E5towDIVUAM0xv9.png": "multi_image_media2.png", 
-                    "img2021-07-07-181833_dooblebugs_2_1412838462206615559_E5toyv_VgAMmKwD.png": "multi_image_media3.png", 
-                    "img2021-07-07-181833_dooblebugs_3_1412838462206615559_E5to1YdUYAI9eek.png": "multi_image_media4.png", 
-                    "gif2021-03-16-210559_dnoodels_1371930768306540546.mp4": "animated_gif_media.mp4", 
+        expected = {"img2021-03-21-040855_sad-istfied_0_1373486756306165763_Ew-a7MFU8AANIL9.jpg": "single_image_media.jpg",
+                    "img2021-07-07-181833_dooblebugs_0_1412838462206615559_E5totsvVUAYexVX.png": "multi_image_media1.png",
+                    "img2021-07-07-181833_dooblebugs_1_1412838462206615559_E5towDIVUAM0xv9.png": "multi_image_media2.png",
+                    "img2021-07-07-181833_dooblebugs_2_1412838462206615559_E5toyv_VgAMmKwD.png": "multi_image_media3.png",
+                    "img2021-07-07-181833_dooblebugs_3_1412838462206615559_E5to1YdUYAI9eek.png": "multi_image_media4.png",
+                    "gif2021-03-16-210559_dnoodels_1371930768306540546.mp4": "animated_gif_media.mp4",
                     "video2021-03-17-022100_megateyourbagel_1372010047056711680.mp4": "video_media.mp4"}
         # Maybe wrap this in an async function somewhere :|
         for tweet in self.cached_tweets.values():
@@ -141,7 +137,7 @@ class Test_MediaDownloadClient(unittest.TestCase):
                 expected_file = os.path.join("tests", "expected", f"{expected[filename]}")
                 with self.subTest(filename=filename):
                     self.assertTrue(filecmp.cmp(all_file, expected_file) and filecmp.cmp(artist_file, expected_file))
-                
+
 
     def test_get_media(self):
         # Test e.g. quote tweet recursion works
@@ -168,12 +164,12 @@ class Test_MediaDownloadClient(unittest.TestCase):
 
     def test_load_history(self):
         # check that the set it loads to ends up having all of the urls
-        expected_urls = {"https://pbs.twimg.com/media/E5totsvVUAYexVX.png:orig", 
-                         "https://pbs.twimg.com/media/E5to1YdUYAI9eek.png:orig", 
-                         "https://video.twimg.com/ext_tw_video/1372009605736194048/pu/vid/1280x720/l3Ujw1tsP7jWvOSg.mp4?tag=12", 
-                         "https://video.twimg.com/tweet_video/EwoThfmWgAs-FAz.mp4", 
-                         "https://pbs.twimg.com/media/Ew-a7MFU8AANIL9.jpg:orig", 
-                         "https://pbs.twimg.com/media/E5toyv_VgAMmKwD.png:orig", 
+        expected_urls = {"https://pbs.twimg.com/media/E5totsvVUAYexVX.png:orig",
+                         "https://pbs.twimg.com/media/E5to1YdUYAI9eek.png:orig",
+                         "https://video.twimg.com/ext_tw_video/1372009605736194048/pu/vid/1280x720/l3Ujw1tsP7jWvOSg.mp4?tag=12",
+                         "https://video.twimg.com/tweet_video/EwoThfmWgAs-FAz.mp4",
+                         "https://pbs.twimg.com/media/Ew-a7MFU8AANIL9.jpg:orig",
+                         "https://pbs.twimg.com/media/E5toyv_VgAMmKwD.png:orig",
                          "https://pbs.twimg.com/media/E5towDIVUAM0xv9.png:orig"}
 
         self.client.media_urls.clear()
@@ -183,6 +179,6 @@ class Test_MediaDownloadClient(unittest.TestCase):
     # Add tests for adding media to queue and getting media from queue? Not sure
 
 
-
 if __name__ == "__main__":
     unittest.main()
+    

--- a/twitter_media_dl/mediadownloadclient.py
+++ b/twitter_media_dl/mediadownloadclient.py
@@ -5,17 +5,19 @@ import glob
 import os
 import warnings
 
+from typing import Any, List, Dict, Set, Tuple, Union
+
 import aiohttp
 import dateutil.parser
 import peony
 import slugify
 
-from typing import Any, List, Dict, Set, Tuple, Union
 
 TweetList = List[peony.data_processing.PeonyResponse]
+MediaList = List[Tuple[peony.data_processing.PeonyResponse, peony.data_processing.JSONData, int]]
 
-def get_media(tweet: peony.data_processing.PeonyResponse, medias: List=[], 
-              depth: int=1, max_depth: int=10):
+def get_media(tweet: peony.data_processing.PeonyResponse, medias: List=None,
+              depth: int=1, max_depth: int=10) -> MediaList:
     """Needs to deal with:
     - plain tweet
     - retweet
@@ -29,23 +31,28 @@ def get_media(tweet: peony.data_processing.PeonyResponse, medias: List=[],
     -------
     medias - list of tuples: [(tweet object, a media in that tweet, media_index)]
     """
-    medias = []  # Set so any duplicate things aren't double counted
-    # first, get media from the tweet itself
+    # First, get media from the tweet itself
+    if medias is None:
+        medias = []
+
     try:
         for media_index, media in enumerate(tweet.extended_entities.media):
             medias.append((tweet, media, media_index))
     except AttributeError:  # tweet has no media itself
         pass
-    # Then, get media from the retweet - what about the retweeted tweets info i.e. username, date, etc.?
+    # Then, get media from the retweet
+    # What about the retweeted tweet's info i.e. username, date, etc.?
     # Lets deal with that later :)
     if depth < max_depth:
         try:
-            medias = get_media(tweet.retweeted_status, medias=medias, depth=depth+1, max_depth=max_depth)
+            medias = get_media(tweet.retweeted_status, medias=medias,
+                               depth=depth+1, max_depth=max_depth)
         except AttributeError:  # retweeted tweet has no media itself
             pass
 
         try:
-            medias = get_media(tweet.quoted_status, medias=medias, depth=depth+1, max_depth=max_depth)
+            medias = get_media(tweet.quoted_status, medias=medias,
+                               depth=depth+1, max_depth=max_depth)
         except AttributeError:  # quoted tweet has no media itself
             pass
 
@@ -61,23 +68,23 @@ def get_media_details(tweets: TweetList) -> List[Dict[str, Union[str, int]]]:
     For quote tweets, returns info on both the quote tweet itself and the quoted tweet.
     This occurs recursively until the "bottom" tweet is reached, or until some level of recursion.
     Same applies to replies.
-    
+
     Parameters
     ----------
     tweets  - A list of tweets / statuses. Each tweet *must* have extended_mode = True
-    
+
     Returns
     -------
     result_list - list of dictionaries containing info about media in the tweets.
     """
     result_list = []
-    
+
     for base_tweet in tweets:
-        medias = get_media(base_tweet)  # Retweets might expand with their base plus retweeted tweet's media
+        medias = get_media(base_tweet)  # Retweets might expand with retweeted tweet's media
         for (tweet, media, media_index) in medias:
             media_info_dict: Dict[str, Union[str, int]] = {}
-                
-            media_info_dict["author"] = slugify.slugify(tweet.user.screen_name)  # Their @xxxx handle (without the @)
+
+            media_info_dict["author"] = slugify.slugify(tweet.user.screen_name)  # Their @xxx handle
             media_info_dict["date"] = tweet.created_at
             media_info_dict["id"] = tweet.id
             media_info_dict["type"] = media.type
@@ -85,22 +92,22 @@ def get_media_details(tweets: TweetList) -> List[Dict[str, Union[str, int]]]:
 
             # Deal with images
             if media.type == "photo":
-                media_info_dict["url"] = media.media_url_https + ":orig"  # To get the highest quality
+                media_info_dict["url"] = media.media_url_https + ":orig"  # Highest quality
 
             # animated_gif and video are treated the same
             elif media.type == "animated_gif" or media.type == "video":
                 max_bitrate = -1
-                # To find highest quality variant
+                # Find highest quality variant
                 for variant in media.video_info.variants:
                     #  some variants have a different content type (m3u8) - ignore these
-                    #  m3u8 is a text-based playlist file apparently - contains some info but it's weird :(
+                    #  m3u8 is a text-based playlist file - contains some info but it's weird :(
                     if variant.content_type == "video/mp4" and variant.bitrate > max_bitrate:
                         max_bitrate = variant.bitrate
                         max_url = variant.url
                 media_info_dict["url"] = max_url
 
             result_list.append(media_info_dict)
-        
+
     return result_list
 
 
@@ -116,7 +123,7 @@ def get_filename(media_info: Dict[str, str]) -> str:
     - video2021-01-30-020601_mrkipler1.mp4
     - img2020-08-02-154843_unrealrui_1_EebTdf4WoAATXof.png
     - gif2020-03-21-122608_rabbitbrush4.mp4
-    
+
     """
     date = dateutil.parser.parse(media_info["date"]).strftime("%Y-%m-%d-%H%M%S")
     artist = media_info["author"]
@@ -125,19 +132,48 @@ def get_filename(media_info: Dict[str, str]) -> str:
     id_ = media_info["id"]
     if media_info["type"] == "photo":
         filename = f"img{date}_{artist}_{index}_{id_}_{url_type}"
-        
+
     elif media_info["type"] == "video":
         filename = f"video{date}_{artist}_{id_}.mp4"
-        
+
     elif media_info["type"] == "animated_gif":
         filename = f"gif{date}_{artist}_{id_}.mp4"
-        
+
     return filename
 
 
-async def download_file(filename: str, media_details: Dict[str, str], 
-                        session: aiohttp.ClientSession, new_session: bool =False, 
-                        base_folder: str =os.path.join(os.path.dirname(__file__), "..", "media")) -> Tuple[str, str]:
+async def download_file(filename: str, media_details: Dict[str, str],
+                        session: aiohttp.ClientSession, new_session: bool =False,
+                        base_folder: str =os.path.join(os.path.dirname(__file__), "..", "media")
+                        ) -> Tuple[str, str]:
+    """
+    Downloads a piece of media from Twitter. The item is downloaded to two folders
+    under base_folder: an "__all__" folder used to collect all pieces of media, and
+    an "{author}" folder used to collect all media from a specific Twitter user.
+
+    Parameters
+    ----------
+    filename: str
+        Filename to give to the downloaded file.
+    media_details: dict
+        Dictionary containing relevant information about the file to download.
+        The used information is the media's author and the url of the media to
+        download from.
+    session: aiohttp.ClientSession
+        An aiohttp session to use when making the request for the data to download.
+
+    new_session: bool, default = False
+        Whether to use a new aiohttp session or not, which would require closing afterwards.
+        Used mainly for testing purposes.
+    base_folder: str, default = os.path.join(os.path.dirname(__file__), "..", "media")
+        Base folder in which to place the downloaded file.
+        Defaults to a sibling folder named 'media'.
+
+    Returns
+    -------
+    (all_folder, artist_folder): (str, str)
+        Returns the locations of the files that were downloaded as a tuple pair.
+    """
     if new_session:
         session = aiohttp.ClientSession()
 
@@ -159,20 +195,20 @@ async def download_file(filename: str, media_details: Dict[str, str],
                             base_file.write(chunk)
                             artist_file.write(chunk)
                         break
-        except FileNotFoundError as e:
+        except FileNotFoundError:
             # Try making the main folder and the artist folder
             os.makedirs(os.path.join(base_folder, "__all__"), exist_ok=True)
             os.makedirs(os.path.join(base_folder, media_details['author']), exist_ok=True)
-        except asyncio.TimeoutError as e:
+        except asyncio.TimeoutError:
             # Timed out :/
             # What to do, what to do...
             # Maybe delay for a bit?
             asyncio.sleep(10)
-        except aiohttp.client_exceptions.ClientConnectorError as e:
+        except aiohttp.client_exceptions.ClientConnectorError:
             # This is a weird error that I don't really understand the cause of :)))
             # But it keeps coming up so I'm just going to tell it to retry
             asyncio.sleep(10)
-        except aiohttp.client_exceptions.ClientPayloadError as e:
+        except aiohttp.client_exceptions.ClientPayloadError:
             # Another strange error that I have just started to get
             # yayyyy
             asyncio.sleep(10)
@@ -189,15 +225,16 @@ async def download_file(filename: str, media_details: Dict[str, str],
 
 client_type: Any = type(peony.PeonyClient)
 class MDCMeta(abc.ABCMeta, client_type):
-    pass
+    """Metaclass for the MediaDownloadClient abstract class, based on a peony client."""
 
 
 class MediaDownloadClient(peony.BasePeonyClient, abc.ABC, metaclass=MDCMeta):
-    def __init__(self, user_id: str, *args, 
+    def __init__(self, user_id: str, *args,
                  base_folder: str=os.path.join(os.path.dirname(__file__), "..", "media"),
                  queuesize: int=100, **kwargs):
         self.base_folder = base_folder
         self.user_id = user_id
+        self.tweet_count = 0
         self.dupes = 0
         self.media_count = 0
         self.media_queue: asyncio.Queue = asyncio.Queue(maxsize=queuesize)
@@ -216,24 +253,30 @@ class MediaDownloadClient(peony.BasePeonyClient, abc.ABC, metaclass=MDCMeta):
         try:
             # Get latest history file
             logfile = glob.glob(os.path.join(search_folder, f"{self.tweet_source}_urls*.txt"))[-1]
-            with open(logfile, "r") as f:
-                self.media_urls.update(line.strip() for line in f.readlines())
+            with open(logfile, "r") as file:
+                self.media_urls.update(line.strip() for line in file.readlines())
         except IndexError:
-            warnings.warn(f"No {self.tweet_source}_urls.txt file found! Continuing with no history...")
+            warnings.warn(f"No {self.tweet_source}_urls.txt file found!"
+                          " Continuing with no history...")
 
 
     def save_history(self):
         """Saves self.urls to a text file."""
         # Move old history to backup folder
-        os.makedirs(os.path.join(self.base_folder, f"{self.tweet_source}_urls_backups"), exist_ok=True)
-        current_media_urls = glob.glob(os.path.join(self.base_folder, f"{self.tweet_source}_urls-*.txt"))
-        for source_file in current_media_urls:  # could be multiple files
-            dest_file = os.path.join(self.base_folder, f"{self.tweet_source}_urls_backups", os.path.basename(source_file))
-            os.rename(source_file, dest_file)
-        
-        # Save new history
+        os.makedirs(os.path.join(self.base_folder, f"{self.tweet_source}_urls_backups"),
+                    exist_ok=True)
+        current_media_urls = glob.glob(os.path.join(self.base_folder,
+                                                    f"{self.tweet_source}_urls-*.txt"))
+        for logfile in current_media_urls:  # could be multiple files
+            dest_file = os.path.join(self.base_folder, f"{self.tweet_source}_urls_backups",
+                                     os.path.basename(logfile))
+            os.rename(logfile, dest_file)
+
+        # Save new history - yyyymmddHHMMSS
         current_time = datetime.datetime.now().strftime("%Y-%m-%d-%H%M%S")
-        new_filename = os.path.join(self.base_folder, f"{self.tweet_source}_urls-{current_time}.txt") # Make new version's filename
+        # Make new version's filename
+        new_filename = os.path.join(self.base_folder,
+                                    f"{self.tweet_source}_urls-{current_time}.txt")
         with open(new_filename, "w") as file:  # Save as a text file to read later
             for url in self.media_urls:
                 file.write(url + "\n")
@@ -245,33 +288,33 @@ class MediaDownloadClient(peony.BasePeonyClient, abc.ABC, metaclass=MDCMeta):
         """Prints progress of downloading to output.
         Prints source, number of pieces of media downloaded, and size of queue."""
         prefix = f"Crawling {self.tweet_source}. ".ljust(17)
-        print(f"{prefix}{self.media_queue.qsize()} tweet(s) in queue, \
-{self.media_count} items downloaded.", end="\r")
+        print(f"{prefix}{self.media_queue.qsize()} tweet(s) in queue,"
+              f" {self.media_count} items downloaded.", end="\r")
 
 
     @abc.abstractmethod
     def send_request(self, count):
         pass
 
-    
+
     @peony.task
     async def add_media_to_queue(self, count: int =800, max_tweets: int =4000) -> None:
         # Start going through the tweets
-        request = self.send_request(count)       
+        request = self.send_request(count)
         responses = request.iterator.with_max_id()
-        
-        self.tweet_count = 0
+
         # responses is a list of Tweet objects
         async for tweets_list in responses:
-            media_details_list = get_media_details(tweets_list)  # pass in a list of tweets, get a list out
+            # In: list(tweets), out: list(media_details)
+            media_details_list = get_media_details(tweets_list)
             for media_details in media_details_list:
                 # Skip ones that have already been downloaded
                 if media_details["url"] in self.media_urls:
                     self.dupes += 1  # Keep track of number of duplicates
                     continue  # URL has already been downloaded, so continue to next one
-                else:
-                    await self.media_queue.put(media_details)  # media_details is a dictionary of media info
-                    self.print_progress()
+
+                await self.media_queue.put(media_details)  # put in dictionary of media info
+                self.print_progress()
 
             self.tweet_count += len(tweets_list)  # keep track of the number of tweets processed
             if self.tweet_count >= max_tweets:
@@ -287,14 +330,15 @@ class MediaDownloadClient(peony.BasePeonyClient, abc.ABC, metaclass=MDCMeta):
             # Deal with ending the consumer
             if media_details is None:
                 self.print_progress()
-                print(f"\n{self.tweet_source.capitalize()} done!")  # Done with progress text, so go to next line
+                # Done with progress text, so go to next line
+                print(f"\n{self.tweet_source.capitalize()} done!")
                 break
-            
+
             # Otherwise, consume the next piece of media
             filename = get_filename(media_details)
-            await download_file(filename, media_details, self._session, 
+            await download_file(filename, media_details, self._session,
                                 base_folder=os.path.join(self.base_folder, self.tweet_source))
-                                
+
             self.media_urls.add(media_details["url"])
             self.media_count += 1
             # Update progress string
@@ -308,7 +352,8 @@ class LikesDownloadClient(MediaDownloadClient):
 
 
     def send_request(self, count):
-        return self.api.favorites.list.get(id=self.user_id, count=count, tweet_mode="extended")
+        return self.api.favorites.list.get(id=self.user_id, count=count,
+                                           tweet_mode="extended")
 
 
 class TimelineDownloadClient(MediaDownloadClient):
@@ -318,4 +363,5 @@ class TimelineDownloadClient(MediaDownloadClient):
 
 
     def send_request(self, count):
-        return self.api.statuses.user_timeline.get(id=self.user_id, count=count, tweet_mode="extended", include_rts=True)
+        return self.api.statuses.user_timeline.get(id=self.user_id, count=count,
+                                                   tweet_mode="extended", include_rts=True)

--- a/twitter_media_dl/twitter_media_dl.py
+++ b/twitter_media_dl/twitter_media_dl.py
@@ -20,12 +20,13 @@ except KeyError as keyerror:
 
 # Parse command line arguments
 sources = ("likes", "timeline", "both")
+log_levels = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
 description = "Download media from Twitter attached to a user's Likes and/or Timeline."
 parser = argparse.ArgumentParser(description=description)
 parser.add_argument("-u", "--user", default=TWITTER_ID, dest="user_id")
 parser.add_argument("-m", "--source", default="both", dest="tweet_source", choices=sources)
 parser.add_argument("-o", "--output", default="media", dest="output_folder")
-parser.add_argument("-l", "--log-level", default="DEBUG", dest="log_level")
+parser.add_argument("-l", "--log-level", default="WARNING", dest="log_level", choices="log_levels")
 parser.add_argument("-p", "--show-progress", dest="show_progress",
                     action="store_true")  # defaults to False
 

--- a/twitter_media_dl/twitter_media_dl.py
+++ b/twitter_media_dl/twitter_media_dl.py
@@ -14,8 +14,8 @@ try:
     CONSUMER_KEY = os.environ["CONSUMER_KEY"]
     CONSUMER_SECRET = os.environ["CONSUMER_SECRET"]
     BEARER_TOKEN = os.environ["BEARER_TOKEN"]
-except KeyError:
-    raise Exception("Not all required environment variables have been defined.")
+except KeyError as keyerror:
+    raise Exception("Not all required environment variables have been defined.") from keyerror
 
 # Parse command line arguments
 sources = ("likes", "timeline", "both")
@@ -24,15 +24,17 @@ parser = argparse.ArgumentParser(description=description)
 parser.add_argument("-u", "--user", default=TWITTER_ID, dest="user_id")
 parser.add_argument("-m", "--source", default="both", dest="tweet_source", choices=sources)
 parser.add_argument("-o", "--output", default="media", dest="output_folder")
+parser.add_argument("-l", "--log_level", default="INFO", dest="log_level")
 
 cmd_args = parser.parse_args()
-            
+
 base_folder = os.path.join(os.path.dirname(__file__), "..", "media")
-kwargs = {"consumer_key": CONSUMER_KEY, 
-          "consumer_secret": CONSUMER_SECRET, 
-          "bearer_token": BEARER_TOKEN, 
-          "auth": peony.oauth.OAuth2Headers, 
-          "base_folder": base_folder}
+kwargs = {"consumer_key": CONSUMER_KEY,
+          "consumer_secret": CONSUMER_SECRET,
+          "bearer_token": BEARER_TOKEN,
+          "auth": peony.oauth.OAuth2Headers,
+          "base_folder": base_folder, 
+          "log_level": cmd_args.log_level}
 
 if cmd_args.tweet_source in ("both", "likes"):
     try:

--- a/twitter_media_dl/twitter_media_dl.py
+++ b/twitter_media_dl/twitter_media_dl.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import os
 
 import dotenv
@@ -24,32 +25,39 @@ parser = argparse.ArgumentParser(description=description)
 parser.add_argument("-u", "--user", default=TWITTER_ID, dest="user_id")
 parser.add_argument("-m", "--source", default="both", dest="tweet_source", choices=sources)
 parser.add_argument("-o", "--output", default="media", dest="output_folder")
-parser.add_argument("-l", "--log_level", default="INFO", dest="log_level")
+parser.add_argument("-l", "--log-level", default="DEBUG", dest="log_level")
+parser.add_argument("-p", "--show-progress", dest="show_progress",
+                    action="store_true")  # defaults to False
 
 cmd_args = parser.parse_args()
+
+logging.basicConfig(format="%(message)s")
+logger = logging.getLogger(__name__)
+logger.setLevel(cmd_args.log_level)
 
 base_folder = os.path.join(os.path.dirname(__file__), "..", "media")
 kwargs = {"consumer_key": CONSUMER_KEY,
           "consumer_secret": CONSUMER_SECRET,
           "bearer_token": BEARER_TOKEN,
           "auth": peony.oauth.OAuth2Headers,
-          "base_folder": base_folder, 
-          "log_level": cmd_args.log_level}
+          "base_folder": base_folder,
+          "log_level": cmd_args.log_level,
+          "show_progress": cmd_args.show_progress}
 
 if cmd_args.tweet_source in ("both", "likes"):
     try:
-        print("Beginning to download likes media...")
+        logger.info("Beginning to download likes media...")
         likes_client = LikesDownloadClient(cmd_args.user_id, **kwargs)
         likes_client.run()
     finally:
-        print("Saving data...")
+        logger.info("Saving data...")
         likes_client.save_history()
 
 if cmd_args.tweet_source in ("both", "timeline"):
     try:
-        print("Beginning to download timeline media...")
+        logger.info("Beginning to download timeline media...")
         timeline_client = TimelineDownloadClient(cmd_args.user_id, **kwargs)
         timeline_client.run()
     finally:
-        print("Saving data...")
+        logger.info("Saving data...")
         timeline_client.save_history()


### PR DESCRIPTION
This branch replaces print statements in the code with equivalent logging statements using Python's inbuilt logging library. This allows the user greater control over the output of the script.
Added command line arguments:
* -l / --log-level
Controls the minimum severity of log messages to output. Options are DEBUG, INFO, WARNING, ERROR, and CRITICAL.

* -p / --show-progress
Controls whether to print the progress of downloading media as the client runs. This progress is printed to a single line using carriage returns, but may not work on narrow terminals nor when writing to a file, so giving the option to disable it was necessary.

Fixes #1 and fixes #2.